### PR TITLE
adjust header icon size

### DIFF
--- a/app/src/main/java/com/example/looksy/ui/components/Header.kt
+++ b/app/src/main/java/com/example/looksy/ui/components/Header.kt
@@ -25,6 +25,7 @@ fun Header(
     headerText: String,
     rightIconContentDescription: String?,
     rightIcon: ImageVector?,
+    rightIconSize: Float = 1F,
     isFirstHeader: Boolean = false,
 ) {
     Box(
@@ -61,7 +62,7 @@ fun Header(
                 Icon(
                     imageVector = rightIcon,
                     contentDescription = rightIconContentDescription,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(rightIconSize)
                 )
             }
         }

--- a/app/src/main/java/com/example/looksy/ui/screens/ClothInformationScreen.kt
+++ b/app/src/main/java/com/example/looksy/ui/screens/ClothInformationScreen.kt
@@ -108,7 +108,8 @@ fun ClothInformationScreen(
             clothesData = clothesData,
             headerText = "Details",
             rightIconContentDescription = "Bearbeiten",
-            rightIcon = Icons.Default.Edit
+            rightIcon = Icons.Default.Edit,
+            rightIconSize = 0.7F
         )
 
         ClothImage(

--- a/app/src/main/java/com/example/looksy/ui/screens/ScreenAddNewClothes.kt
+++ b/app/src/main/java/com/example/looksy/ui/screens/ScreenAddNewClothes.kt
@@ -111,7 +111,8 @@ fun AddNewClothesScreen(
             clothesData = clothesToEdit,
             headerText = if (clothesIdToEdit != null) "Bearbeiten" else "Hinzufügen",
             rightIconContentDescription = if (clothesIdToEdit != null) "Löschen" else null,
-            rightIcon = if (clothesIdToEdit != null) Icons.Default.Delete else null
+            rightIcon = if (clothesIdToEdit != null) Icons.Default.Delete else null,
+            rightIconSize = 0.7F,
         )
         },
         floatingActionButton = {


### PR DESCRIPTION
Die Größe des Icons im Header kann jetzt über den Parameter _rightIconSize_ angepasst werden.

Die Größe der Edit und Delete Icons wurde angepasst 
<img width="269,75" height="60" alt="grafik" src="https://github.com/user-attachments/assets/1b772332-4538-44fd-ac1d-062a83e6fb32" />

fixes #41 
